### PR TITLE
Add 'Event Delete' Role

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 import discord
 
 from db.dbase import DBase
-from db.query_wrappers import get_event_role
+from db.query_wrappers import get_event_role, get_event_delete_role
 from cogs.utils.messages import delete_all, MessageManager
 from cogs.utils.checks import is_event, is_int
 from cogs.utils import constants
@@ -185,14 +185,14 @@ class Events:
 
     async def delete_event(self, guild, title, member, channel):
         """Delete an event and update the events channel on success"""
-        event_role = get_event_role(guild)
+        event_delete_role = get_event_delete_role(guild)
         with DBase() as db:
             rows = db.get_event_creator(guild.id, title)
 
         if len(rows) and len(rows[0]):
             creator_id = rows[0][0]
 
-        if member.permissions_in(channel).manage_guild or (member.id == creator_id) or (event_role and member.top_role >= event_role):
+        if member.permissions_in(channel).manage_guild or (member.id == creator_id) or (event_delete_role and member.top_role >= event_delete_role):
             with DBase() as db:
                 deleted = db.delete_event(guild.id, title)
             if deleted:

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 import discord
 
 from db.dbase import DBase
-from db.query_wrappers import get_event_role
+from db.query_wrappers import get_event_role, get_event_delete_role
 from cogs.utils.messages import MessageManager
 from cogs.utils.format import format_role_name
 
@@ -97,6 +97,53 @@ class Settings:
 
             await manager.say("The current event role is: **{}**\n\n".format(role_display)
                             + "To change the event role, use '{}settings seteventrole <role_name>'".format(ctx.prefix))
+            await manager.clear()
+
+
+    @settings.command()
+    @commands.guild_only()
+    @commands.has_permissions(manage_guild=True)
+    async def seteventdeleterole(self, ctx, *, event_role):
+        """Set the lowest role that is able to delete events (Manage Server only)
+        By default, deleting events requires the user to have Administrator permissions.
+        But if an event role is set, then any user that is of the event role or higher may
+        delete events.
+        **Note:** Mentioning the role directly with this command will not work. You must provide
+        only the name of the role without mentioning it.
+        """
+        manager = MessageManager(self.bot, ctx.author, ctx.channel, [ctx.message])
+
+        guild_event_delete_role = None
+        for role in ctx.guild.roles:
+            if role.name in (event_role, "@{}".format(event_role)):
+                guild_event_delete_role = role
+
+        if not guild_event_delete_role:
+            await manager.say("I couldn't find a role called **{}** on this server.\n".format(event_role)
+                            + "Note that you must provide only the name of the role. "
+                            + "Mentioning it with the @ sign won't work.")
+            return await manager.clear()
+
+        with DBase() as db:
+            db.set_event_delete_role_id(ctx.guild.id, guild_event_delete_role.id)
+
+        await manager.say("The event delete role has been set to: **{}**".format(format_role_name(guild_event_delete_role)))
+        return await manager.clear()
+
+
+    @seteventdeleterole.error
+    async def seteventdeleterole_error(self, ctx, error):
+        if isinstance(error, commands.MissingRequiredArgument):
+            manager = MessageManager(self.bot, ctx.author, ctx.channel, [ctx.message])
+            event_role = get_event_delete_role(ctx.guild)
+
+            if not event_role:
+                role_display = 'None (anyone can delete events)'
+            else:
+                role_display = format_role_name(event_role)
+
+            await manager.say("The current event delete role is: **{}**\n\n".format(role_display)
+                            + "To change the event delete role, use '{}settings seteventdeleterole <role_name>'".format(ctx.prefix))
             await manager.clear()
 
 

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -106,8 +106,8 @@ class Settings:
     async def seteventdeleterole(self, ctx, *, event_role):
         """Set the lowest role that is able to delete events (Manage Server only)
         By default, deleting events requires the user to have Administrator permissions.
-        But if an event role is set, then any user that is of the event role or higher may
-        delete events.
+        But if an event delete role is set, then any user that is of the event delete role or
+        higher may delete events.
         **Note:** Mentioning the role directly with this command will not work. You must provide
         only the name of the role without mentioning it.
         """

--- a/db/dbase.py
+++ b/db/dbase.py
@@ -226,9 +226,28 @@ class DBase:
         self.conn.commit()
         return affected_count
 
+    def set_event_delete_role_id(self, guild_id, event_delete_role_id):
+        sql = """
+              UPDATE guilds
+              SET event_delete_role_id = %s
+              WHERE guild_id = %s;
+              """
+        affected_count = self.cur.execute(sql, (event_delete_role_id, guild_id))
+        self.conn.commit()
+        return affected_count
+
     def get_event_role_id(self, guild_id):
         sql = """
               SELECT event_role_id
+              FROM guilds
+              WHERE guild_id = %s
+              """
+        self.cur.execute(sql, (guild_id,))
+        return self.cur.fetchall()
+
+    def get_event_delete_role_id(self, guild_id):
+        sql = """
+              SELECT event_delete_role_id
               FROM guilds
               WHERE guild_id = %s
               """

--- a/db/query_wrappers.py
+++ b/db/query_wrappers.py
@@ -9,3 +9,13 @@ def get_event_role(guild):
         for role in guild.roles:
             if role.id == rows[0][0]:
                 return role
+
+def get_event_delete_role(guild):
+    """Return the event role, if it exists"""
+    with DBase() as db:
+        rows = db.get_event_delete_role_id(guild.id)
+
+    if len(rows) and len(rows[0]):
+        for role in guild.roles:
+            if role.id == rows[0][0]:
+                return role

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE guilds (
 	prefix VARCHAR(5) NOT NULL DEFAULT '!',
 	clear_spam BOOLEAN NOT NULL DEFAULT 0,
 	event_role_id BIGINT,
+	event_delete_role_id BIGINT,
 	PRIMARY KEY(guild_id)
 );
 


### PR DESCRIPTION
Adds an event delete role setting that controls who can delete events. We wanted the ability for mostly anyone to create events on our clan server but we didn't want just anyone to be able to delete the events necessarily unless they created them.