### PR TITLE
Add a 'maybe' option to event attendance so that people can indicate …

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -141,6 +141,7 @@ class Events:
                 msg = await events_channel.send(embed=event_embed)
                 await msg.add_reaction("\N{WHITE HEAVY CHECK MARK}")
                 await msg.add_reaction("\N{CROSS MARK}")
+                await msg.add_reaction("\N{WHITE QUESTION MARK ORNAMENT}")
         else:
             await events_channel.send("There are no upcoming events.")
 
@@ -167,6 +168,8 @@ class Events:
                 await self.set_attendance(member, guild, 1, title, message)
             elif emoji.name == "\N{CROSS MARK}":
                 await self.set_attendance(member, guild, 0, title, message)
+            elif emoji.name == "\N{WHITE QUESTION MARK ORNAMENT}":
+                await self.set_attendance(member, guild, None, title, message)
             elif emoji.name == "\N{SKULL}":
                 deleted = await self.delete_event(guild, title, member, channel)
 
@@ -233,6 +236,7 @@ class Events:
         creator_id = event.get('user_id')
         accepted = event.get('accepted')
         declined = event.get('declined')
+        maybe = event.get('maybe')
         max_members = event.get('max_members')
 
         embed_msg = discord.Embed(color=constants.BLUE)
@@ -280,6 +284,17 @@ class Events:
             embed_msg.add_field(name="Declined", value=text)
         else:
             embed_msg.add_field(name="Declined", value="-")
+
+        if maybe:
+            maybe_list = maybe.split(',')
+            text = ""
+            for user_id in maybe_list:
+                member = guild.get_member(int(user_id))
+                if member:
+                    text += "{}\n".format(member.display_name)
+            embed_msg.add_field(name="Maybe", value=text)
+        else:
+            embed_msg.add_field(name="Maybe", value="-")
 
         if accepted and max_members:
             standby_list = accepted.split(',')[max_members:]

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -169,7 +169,7 @@ class Events:
             elif emoji.name == "\N{CROSS MARK}":
                 await self.set_attendance(member, guild, 0, title, message)
             elif emoji.name == "\N{WHITE QUESTION MARK ORNAMENT}":
-                await self.set_attendance(member, guild, None, title, message)
+                await self.set_attendance(member, guild, 2, title, message)
             elif emoji.name == "\N{SKULL}":
                 deleted = await self.delete_event(guild, title, member, channel)
 

--- a/cogs/utils/checks.py
+++ b/cogs/utils/checks.py
@@ -10,9 +10,11 @@ def is_event(message):
                 and embed.fields[0]
                 and embed.fields[1]
                 and embed.fields[2]
+                and embed.fields[3]
                 and embed.fields[0].name == "Time"
                 and embed.fields[1].name.startswith("Accepted")
-                and embed.fields[2].name.startswith("Declined"))
+                and embed.fields[2].name.startswith("Declined")
+                and embed.fields[3].name.startswith("Maybe"))
 
 
 def is_int(x):

--- a/db/dbase.py
+++ b/db/dbase.py
@@ -142,7 +142,7 @@ class DBase:
                     FROM user_event
                     WHERE user_event.guild_id = %s
                     AND user_event.title = %s
-                    AND user_event.attending IS NULL)
+                    AND user_event.attending = 2)
                     AS maybe,
                     max_members
                   FROM events
@@ -211,7 +211,7 @@ class DBase:
                     FROM user_event
                     WHERE user_event.guild_id = %s
                     AND user_event.title = event_title
-                    AND user_event.attending IS NULL)
+                    AND user_event.attending = 2)
                     AS maybe,
                     max_members
                   FROM events
@@ -363,8 +363,6 @@ class DBase:
 
 
     def update_attendance(self, user_id, guild_id, attending, title, last_updated):
-        if attending == None:
-            attending = 'NULL'
         with self.connection.cursor() as cursor:
             sql = """
                   INSERT INTO user_event (user_id, guild_id, title, attending, last_updated)

--- a/db/dbase.py
+++ b/db/dbase.py
@@ -138,6 +138,12 @@ class DBase:
                     AND user_event.title = %s
                     AND user_event.attending = 0)
                     AS declined,
+                    SELECT GROUP_CONCAT(DISTINCT user_id ORDER BY last_updated)
+                    FROM user_event
+                    WHERE user_event.guild_id = %s
+                    AND user_event.title = %s
+                    AND user_event.attending IS NULL)
+                    AS maybe,
                     max_members
                   FROM events
                   WHERE guild_id = %s
@@ -201,6 +207,12 @@ class DBase:
                     AND user_event.title = event_title
                     AND user_event.attending = 0)
                     AS declined,
+                    SELECT GROUP_CONCAT(DISTINCT user_id ORDER BY last_updated)
+                    FROM user_event
+                    WHERE user_event.guild_id = %s
+                    AND user_event.title = event_title
+                    AND user_event.attending IS NULL)
+                    AS maybe,
                     max_members
                   FROM events
                   WHERE events.guild_id = %s
@@ -351,6 +363,8 @@ class DBase:
 
 
     def update_attendance(self, user_id, guild_id, attending, title, last_updated):
+        if attending == None:
+            attending = 'NULL'
         with self.connection.cursor() as cursor:
             sql = """
                   INSERT INTO user_event (user_id, guild_id, title, attending, last_updated)

--- a/db/migrations/event-maybes.sql
+++ b/db/migrations/event-maybes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_event MODIFY attending INT NOT NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE user_event (
 	user_id BIGINT NOT NULL,
 	guild_id BIGINT NOT NULL,
 	title VARCHAR(256) NOT NULL,
-	attending BOOLEAN NOT NULL,
+	attending BOOLEAN,
 	last_updated DATETIME NOT NULL,
 	PRIMARY KEY (user_id, guild_id, title),
 	FOREIGN KEY (guild_id, title) REFERENCES events(guild_id, title)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE user_event (
 	user_id BIGINT NOT NULL,
 	guild_id BIGINT NOT NULL,
 	title VARCHAR(256) NOT NULL,
-	attending BOOLEAN,
+	attending INT NOT NULL,
 	last_updated DATETIME NOT NULL,
 	PRIMARY KEY (user_id, guild_id, title),
 	FOREIGN KEY (guild_id, title) REFERENCES events(guild_id, title)


### PR DESCRIPTION
…interest without committing to the event.

I'm not sure how you want to do the DB migration, but you'd just need to remove the 'NOT NULL' constraint on the 'attending' column of the 'user_event' table.
I must also admit that this is untested.